### PR TITLE
#169795605 bug(create-button-to-home-page):create button to home page

### DIFF
--- a/UI/pages/createintervention.html
+++ b/UI/pages/createintervention.html
@@ -62,7 +62,7 @@
                               Upload Video<input type="file" value="Video" required>
 
                               <button>
-                                   <a href="./userprofile.html" class="submit">Create</a>
+                                   <a href="../index.html" class="submit">Create</a>
                               </button>
               
                           </form>

--- a/UI/pages/createredfrag.html
+++ b/UI/pages/createredfrag.html
@@ -62,7 +62,7 @@
                               Upload Video<input type="file" value="Video" required>
 
                               <button>
-                                   <a href="./userprofile.html" class="submit">Create</a>
+                                   <a href="../index.html" class="submit">Create</a>
                               </button>
               
                           </form>


### PR DESCRIPTION
When user create red-flag event go back to the home page
When user create intervention event go back to the home page

[Finishes:#169795605]

> #### What does this PR do?
> To go back to the home page after creating an event
>
> #### Description of Task to be completed
> I change the link on the create button
>
> #### How should this be manually tested?
> Using a browser 
> #### Any background context you want to provide?
> None
> #### What are the relevant pivotal tracker stories?
> #169795605
> #### Screenshots (if appropriate)
> 
![Button-create-home2](https://user-images.githubusercontent.com/54438606/69004208-fd7dcf80-0917-11ea-99a0-5f33db78d209.PNG)
![Button-create-home1](https://user-images.githubusercontent.com/54438606/69004209-fd7dcf80-0917-11ea-95e4-1c18ff620c13.PNG)

