### PR TITLE
#169796553 bug(remove-edit-delete-in-selector): remove edit and delete in selector

### DIFF
--- a/UI/css/style.css
+++ b/UI/css/style.css
@@ -275,6 +275,14 @@ h3 {
 .tablelistcontents tbody tr:last-of-type {
 border-bottom: var(--header-footer-background);
 }
+tbody tr td ul li {
+     list-style-type: none;
+     text-align: left;
+}
+tbody tr td ul li a{
+     text-decoration: none;
+     color: blue;
+}
 
 /* End of Contents */
 

--- a/UI/pages/userlistcontents.html
+++ b/UI/pages/userlistcontents.html
@@ -102,14 +102,14 @@
                                         </td>
                                         <td>It's the time to figth against corruption</td>
                                         <td>
-                                             <select>
-                                                  <option>
+                                             <ul>
+                                                  <li>
                                                        <a href="#">Edit</a>
-                                                  </option>
-                                                  <option>
+                                                  </li>
+                                                  <li>
                                                        <a href="#">Delete</a>
-                                                  </option>
-                                             </select> 
+                                                  </li>
+                                             </ul> 
                                         </td>
                                    </tr>
                     
@@ -147,14 +147,14 @@
                                         </td>
                                         <td>It's the time to figth against corruption</td>
                                         <td>
-                                             <select>
-                                                  <option>
+                                             <ul>
+                                                  <li>
                                                        <a href="#">Edit</a>
-                                                  </option>
-                                                  <option>
+                                                  </li>
+                                                  <li>
                                                        <a href="#">Delete</a>
-                                                  </option>
-                                             </select> 
+                                                  </li>
+                                             </ul>
                                         </td>
                                    </tr>
                     
@@ -192,14 +192,14 @@
                                         </td>
                                         <td>It's the time to figth against corruption</td>
                                         <td>
-                                             <select>
-                                                  <option>
+                                             <ul>
+                                                  <li>
                                                        <a href="#">Edit</a>
-                                                  </option>
-                                                  <option>
+                                                  </li>
+                                                  <li>
                                                        <a href="#">Delete</a>
-                                                  </option>
-                                             </select> 
+                                                  </li>
+                                             </ul> 
                                         </td>
                                    </tr>
                     
@@ -237,14 +237,14 @@
                                         </td>
                                         <td>We can help Govenment to interven in our local area</td>
                                         <td>
-                                             <select>
-                                                  <option>
+                                             <ul>
+                                                  <li>
                                                        <a href="#">Edit</a>
-                                                  </option>
-                                                  <option>
+                                                  </li>
+                                                  <li>
                                                        <a href="#">Delete</a>
-                                                  </option>
-                                             </select>                                             
+                                                  </li>
+                                             </ul> 
                                         </td>
                                    </tr>
                     
@@ -282,14 +282,14 @@
                                         </td>
                                         <td>We can help Government to interven in our local area</td>
                                         <td>
-                                             <select>
-                                                  <option>
+                                             <ul>
+                                                  <li>
                                                        <a href="#">Edit</a>
-                                                  </option>
-                                                  <option>
+                                                  </li>
+                                                  <li>
                                                        <a href="#">Delete</a>
-                                                  </option>
-                                             </select> 
+                                                  </li>
+                                             </ul> 
                                         </td>
                                    </tr>
                     
@@ -327,14 +327,14 @@
                                         </td>
                                         <td>We can help Government to interven in our local area</td>
                                         <td>
-                                             <select>
-                                                  <option>
+                                             <ul>
+                                                  <li>
                                                        <a href="#">Edit</a>
-                                                  </option>
-                                                  <option>
+                                                  </li>
+                                                  <li>
                                                        <a href="#">Delete</a>
-                                                  </option>
-                                             </select> 
+                                                  </li>
+                                             </ul> 
                                         </td>
                                    </tr>
                     


### PR DESCRIPTION
User should use edit or delete without select option

[Finishes:#169796553]

> #### What does this PR do?
> User should use edit or delete without select option
>
> #### Description of Task to be completed
> To remove edit and delete in select option
>
> #### How should this be manually tested?
> Using a browser
> #### Any background context you want to provide?
> None
> #### What are the relevant pivotal tracker stories?
> - #### 169796553
> #### Screenshots (if appropriate)
> 
![Edit-delete](https://user-images.githubusercontent.com/54438606/69004626-569d3180-091f-11ea-80a5-4ffbbdd07f4f.PNG)
